### PR TITLE
Fix Deprecations

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
+++ b/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import Photos
 
 /// Defines a number of methods that will be called throughout the lifecycle of the TatsiPickerViewController. See the config for more options.
-public protocol TatsiPickerViewControllerDelegate: class {
+public protocol TatsiPickerViewControllerDelegate: AnyObject {
 
     /// Called when the user has selected assets (and tapped the done button).
     ///

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Photos
 
-internal protocol AlbumsViewControllerDelegate: class {
+internal protocol AlbumsViewControllerDelegate: AnyObject {
     
     /// Called when an album is selected in the album list.
     ///


### PR DESCRIPTION
Fixes the deprecation:

```swift
Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
```