### PR TITLE
Fix done button to use UIButton selector

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
+++ b/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import Photos
 
 /// Defines a number of methods that will be called throughout the lifecycle of the TatsiPickerViewController. See the config for more options.
-public protocol TatsiPickerViewControllerDelegate: class {
+public protocol TatsiPickerViewControllerDelegate: AnyObject {
 
     /// Called when the user has selected assets (and tapped the done button).
     ///

--- a/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
+++ b/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
@@ -45,7 +45,7 @@ public protocol TatsiPickerViewControllerDelegate: AnyObject {
     ///
     /// - Parameter pickerViewController: The picker view controller the done button will be placed in.
     /// - Returns: The done button that should be used inside the picker view controller.
-    func doneBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIBarButtonItem?
+    func doneBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIButton?
 }
 
 extension TatsiPickerViewControllerDelegate {
@@ -63,7 +63,7 @@ extension TatsiPickerViewControllerDelegate {
         return nil
     }
     
-    public func doneBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIBarButtonItem? {
+    public func doneBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIButton? {
         return nil
     }
     

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Photos
 
-internal protocol AlbumsViewControllerDelegate: class {
+internal protocol AlbumsViewControllerDelegate: AnyObject {
     
     /// Called when an album is selected in the album list.
     ///

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -100,14 +100,22 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         }
     }
     
-    lazy fileprivate var doneButton: UIBarButtonItem = {
-        let buttonitem = self.pickerViewController?.customDoneButtonItem() ?? UIBarButtonItem(barButtonSystemItem: .done, target: nil, action: nil)
-        buttonitem.target = self
-        buttonitem.action = #selector(AssetsGridViewController.done(_:))
-        buttonitem.accessibilityIdentifier = "tatsi.button.done"
-        buttonitem.tintColor = self.config?.colors.link ?? TatsiConfig.default.colors.link
-        return buttonitem
-    }()
+  lazy fileprivate var doneButton: UIBarButtonItem = {
+    // If we have a custom button bar item that uses a UIButton, we cannot leverage the `target` and `action` for the UIButtonBar. We must use the UIButton.addTarget
+    if let button = self.pickerViewController?.customDoneButtonItem() {
+      button.addTarget(self, action: #selector(done), for: .touchUpInside)
+      let doneBarButton = UIBarButtonItem(customView: button)
+      doneBarButton.accessibilityIdentifier = "tatsi.button.done"
+      doneBarButton.tintColor = self.config?.colors.link ?? TatsiConfig.default.colors.link
+      return doneBarButton
+    } else {
+      // We use the default
+      let defaultDoneBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
+      defaultDoneBarButton.accessibilityIdentifier = "tatsi.button.done"
+      defaultDoneBarButton.tintColor = self.config?.colors.link ?? TatsiConfig.default.colors.link
+      return defaultDoneBarButton
+    }
+  }()
     
     // MARK: - Initializers
     

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -79,7 +79,7 @@ final public class TatsiPickerViewController: UINavigationController {
         return self.pickerDelegate?.cancelBarButtonItem(for: self)
     }
     
-    internal func customDoneButtonItem() -> UIBarButtonItem? {
+    internal func customDoneButtonItem() -> UIButton? {
         return self.pickerDelegate?.doneBarButtonItem(for: self)
     }
 


### PR DESCRIPTION
Because we are creating a `UIBarButtonItem` that is using a `customView` which has an underlying implementation of `UIButton`, we must specify the target and selector on the `UIButton` itself.

Because the original implementation for a custom `UIBarButtonItem` Sets the `target` and `action` properties on the `UIBarButtonItem` itself, the `selector` function is never called because the `selector` needs to on the `UIButton`.

We could create our UIButton and specify the `selector` but then the delegate method for getting a custom done button is never called because we can't access it.