### PR TITLE
Remove improper usage of self.

### DIFF
--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -94,21 +94,21 @@ public struct TatsiConfig {
   private var bannedAlbumSubtypes: [PHAssetCollectionSubtype] {
     var bannedAlbumSubtypes: [PHAssetCollectionSubtype] = []
     
-    if self.showRecentlyAddedAlbum == false {
+    if showRecentlyAddedAlbum == false {
       bannedAlbumSubtypes.append(.smartAlbumRecentlyAdded)
     }
     
-    if self.showHiddenAlbum == false {
+    if showHiddenAlbum == false {
       bannedAlbumSubtypes.append(.smartAlbumAllHidden)
     }
     
-    if self.supportedMediaTypes.contains(PHAssetMediaType.video) == false {
+    if supportedMediaTypes.contains(PHAssetMediaType.video) == false {
       bannedAlbumSubtypes.append(.smartAlbumVideos)
       bannedAlbumSubtypes.append(.smartAlbumTimelapses)
       bannedAlbumSubtypes.append(.smartAlbumSlomoVideos)
     }
     
-    if self.supportedMediaTypes.contains(PHAssetMediaType.image) == false {
+    if supportedMediaTypes.contains(PHAssetMediaType.image) == false {
       bannedAlbumSubtypes.append(.smartAlbumPanoramas)
       bannedAlbumSubtypes.append(.smartAlbumBursts)
       bannedAlbumSubtypes.append(.smartAlbumSelfPortraits)
@@ -133,12 +133,12 @@ public struct TatsiConfig {
     
     var predicates = [NSPredicate]()
     
-    let mediaTypePredicates = self.supportedMediaTypes.compactMap({ (mediaType) -> NSPredicate? in
+    let mediaTypePredicates = supportedMediaTypes.compactMap({ (mediaType) -> NSPredicate? in
       return NSPredicate(format: "(mediaType == %ld)", mediaType.rawValue)
     })
     predicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: mediaTypePredicates))
     
-    if let mediaSubtypes = self.supportedMediaSubTypes {
+    if let mediaSubtypes = supportedMediaSubTypes {
       let mediaSubtypePredicates = mediaSubtypes.compactMap({ (mediaSubtype) -> NSPredicate? in
         return NSPredicate(format: "mediaSubtype == %d", mediaSubtype.rawValue)
       })
@@ -166,7 +166,7 @@ public struct TatsiConfig {
     
     if self.showEmptyAlbums == false {
       // If we don't allow empty albums, we hide the albums that have less than 1 asset.
-      guard !assetCollection.isEmpty(for: self.assetFetchOptions()) else {
+      guard !assetCollection.isEmpty(for: assetFetchOptions()) else {
         return false
       }
     }
@@ -177,11 +177,11 @@ public struct TatsiConfig {
     }
     
     /// We can only check the recently deleted collection based on its name at the moment.
-    if self.showRecentlyDeletedAlbum == false && assetCollection.isRecentlyDeletedCollection {
+    if showRecentlyDeletedAlbum == false && assetCollection.isRecentlyDeletedCollection {
       return false
     }
     
-    return !self.bannedAlbumSubtypes.contains(assetCollection.assetCollectionSubtype)
+    return !bannedAlbumSubtypes.contains(assetCollection.assetCollectionSubtype)
   }
   
 }

--- a/Tatsi/Extensions/CGSizeExtensions.swift
+++ b/Tatsi/Extensions/CGSizeExtensions.swift
@@ -11,6 +11,6 @@ import UIKit
 extension CGSize {
   
   internal func scaled(with scale: CGFloat) -> CGSize {
-    return CGSize(width: self.width * scale, height: self.height * scale)
+    return CGSize(width: width * scale, height: height * scale)
   }
 }

--- a/Tatsi/Extensions/PHAssetCollectionExtensions.swift
+++ b/Tatsi/Extensions/PHAssetCollectionExtensions.swift
@@ -57,7 +57,7 @@ extension PHAssetCollection {
   }
   
   internal func isEmpty(for fetchOptions: PHFetchOptions? = nil) -> Bool {
-    guard self.estimatedAssetCount > 0 || self.estimatedAssetCount == NSNotFound else {
+    guard estimatedAssetCount > 0 || estimatedAssetCount == NSNotFound else {
       return true
     }
     if let fetchOptions = fetchOptions?.copy() as? PHFetchOptions {
@@ -70,12 +70,12 @@ extension PHAssetCollection {
   
   internal var isRecentlyDeletedCollection: Bool {
     // The recently deleted collection can only be a smart album.
-    guard self.assetCollectionType == .smartAlbum else {
+    guard assetCollectionType == .smartAlbum else {
       return false
     }
     
     /// Currently there is no app store passable or reliable way to check if the album is the "recently deleted" album. That's why we simply check the title.
-    guard let title = self.localizedTitle?.lowercased() else {
+    guard let title = localizedTitle?.lowercased() else {
       return false
     }
     let collectionNames = [
@@ -90,7 +90,7 @@ extension PHAssetCollection {
   }
   
   internal var isUserLibrary: Bool {
-    return self.assetCollectionType == .smartAlbum && self.assetCollectionSubtype == .smartAlbumUserLibrary
+    return assetCollectionType == .smartAlbum && assetCollectionSubtype == .smartAlbumUserLibrary
   }
   
 }

--- a/Tatsi/Protocols/PickerViewController.swift
+++ b/Tatsi/Protocols/PickerViewController.swift
@@ -25,36 +25,36 @@ protocol PickerViewController {
 extension PickerViewController where Self: UIViewController {
   
   var pickerViewController: TatsiPickerViewController? {
-    return self.navigationController as? TatsiPickerViewController
+    return navigationController as? TatsiPickerViewController
   }
   
   var config: TatsiConfig? {
-    return self.pickerViewController?.config
+    return pickerViewController?.config
   }
   
   var delegate: TatsiPickerViewControllerDelegate? {
-    return self.pickerViewController?.pickerDelegate
+    return pickerViewController?.pickerDelegate
   }
   
   func didSelectCollection(_ collection: PHAssetCollection) {
-    guard let viewController = self.pickerViewController else {
+    guard let viewController = pickerViewController else {
       return
     }
-    self.delegate?.pickerViewController(viewController, didSelectCollection: collection)
+    delegate?.pickerViewController(viewController, didSelectCollection: collection)
   }
   
   func finishPicking(with assets: [PHAsset]) {
     guard let viewController = self.pickerViewController else {
       return
     }
-    self.delegate?.pickerViewController(viewController, didPickAssets: assets)
+    delegate?.pickerViewController(viewController, didPickAssets: assets)
   }
   
   func cancelPicking() {
-    guard let viewController = self.pickerViewController else {
+    guard let viewController = pickerViewController else {
       return
     }
-    self.delegate?.pickerViewControllerDidCancel(viewController)
+    delegate?.pickerViewControllerDidCancel(viewController)
   }
   
 }

--- a/Tatsi/UIElements/AlbumEmptyView.swift
+++ b/Tatsi/UIElements/AlbumEmptyView.swift
@@ -56,7 +56,7 @@ final internal class AlbumEmptyView: UIView {
   }()
   
   lazy private var stackView: UIStackView = {
-    let stackView = UIStackView(arrangedSubviews: [self.titleLabel, self.messageLabel])
+    let stackView = UIStackView(arrangedSubviews: [titleLabel, messageLabel])
     stackView.axis = .vertical
     stackView.translatesAutoresizingMaskIntoConstraints = false
     stackView.spacing = 14
@@ -67,8 +67,8 @@ final internal class AlbumEmptyView: UIView {
     didSet {
       guard let colors = colors else { return }
       
-      self.titleLabel.textColor = colors.label
-      self.messageLabel.textColor = colors.secondaryLabel
+      titleLabel.textColor = colors.label
+      messageLabel.textColor = colors.secondaryLabel
     }
   }
   
@@ -77,7 +77,7 @@ final internal class AlbumEmptyView: UIView {
     
     super.init(frame: CGRect())
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -85,22 +85,22 @@ final internal class AlbumEmptyView: UIView {
   }
   
   private func setupView() {
-    self.addSubview(self.stackView)
+    addSubview(stackView)
     
-    self.titleLabel.text = self.state.title
-    self.messageLabel.text = self.state.message
-    self.messageLabel.isHidden = self.messageLabel.text == nil
+    titleLabel.text = state.title
+    messageLabel.text = state.message
+    messageLabel.isHidden = messageLabel.text == nil
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     let constraints = [
-      self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-      self.stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      self.stackView.leadingAnchor.constraint(greaterThanOrEqualTo: self.layoutMarginsGuide.leadingAnchor),
-      self.trailingAnchor.constraint(greaterThanOrEqualTo: self.layoutMarginsGuide.trailingAnchor),
-      self.stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 250)
+      stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+      stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+      stackView.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor),
+      trailingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
+      stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 250)
     ]
     
     NSLayoutConstraint.activate(constraints)

--- a/Tatsi/UIElements/AlbumImageView.swift
+++ b/Tatsi/UIElements/AlbumImageView.swift
@@ -12,22 +12,22 @@ final internal class AlbumImageView: UIView {
   
   var linesColor = UIColor.black {
     didSet {
-      self.setNeedsDisplay()
+      setNeedsDisplay()
     }
   }
   
   var placeholderColor = UIColor(red: 226 / 255, green: 225 / 255, blue: 230 / 255, alpha: 1) {
     didSet {
-      self.imageView.backgroundColor = self.placeholderColor
+      imageView.backgroundColor = placeholderColor
     }
   }
   
   var image: UIImage? {
     set {
-      self.imageView.image = newValue
+      imageView.image = newValue
     }
     get {
-      return self.imageView.image
+      return imageView.image
     }
   }
   
@@ -39,23 +39,23 @@ final internal class AlbumImageView: UIView {
     let imageView = UIImageView()
     imageView.clipsToBounds = true
     imageView.isOpaque = true
-    imageView.backgroundColor = self.placeholderColor
+    imageView.backgroundColor = placeholderColor
     imageView.contentMode = UIView.ContentMode.scaleAspectFill
     return imageView
   }()
   
   override init(frame: CGRect) {
     super.init(frame: frame)
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    self.setupView()
+    setupView()
   }
   
   func setupView() {
-    self.addSubview(self.imageView)
+    addSubview(self.imageView)
   }
   
   // Only override drawRect: if you perform custom drawing.
@@ -63,11 +63,11 @@ final internal class AlbumImageView: UIView {
   override func draw(_ rect: CGRect) {
     // Drawing code
     let firstLinePath = UIBezierPath(rect: CGRect(x: 7, y: 0, width: rect.width - ( 7 * 2 ), height: 1 / UIScreen.main.scale))
-    self.linesColor.withAlphaComponent(0.4).setFill()
+    linesColor.withAlphaComponent(0.4).setFill()
     firstLinePath.fill()
     
     let secondLinePath = UIBezierPath(rect: CGRect(x: 4, y: 2, width: rect.width - ( 4 * 2 ), height: 1 / UIScreen.main.scale))
-    self.linesColor.withAlphaComponent(0.6).setFill()
+    linesColor.withAlphaComponent(0.6).setFill()
     secondLinePath.fill()
   }
   
@@ -77,7 +77,7 @@ final internal class AlbumImageView: UIView {
   
   override func layoutSubviews() {
     super.layoutSubviews()
-    self.imageView.frame = CGRect(x: 0, y: 4, width: self.bounds.width, height: self.bounds.height - 4)
+    imageView.frame = CGRect(x: 0, y: 4, width: bounds.width, height: bounds.height - 4)
   }
   
 }

--- a/Tatsi/UIElements/AlbumTitleView.swift
+++ b/Tatsi/UIElements/AlbumTitleView.swift
@@ -14,20 +14,20 @@ final class AlbumTitleView: UIControl {
   /// The title that should be displayed. This can be the name of the album.
   var title: String? {
     didSet {
-      self.accessibilityLabel = self.title
-      self.titleLabel.text = self.title
+      accessibilityLabel = title
+      titleLabel.text = title
     }
   }
   
   /// If the arrow should flip 180 degrees. Can be used in an animation block.
   var flipArrow: Bool = false {
     didSet {
-      guard self.flipArrow != oldValue else {
+      guard flipArrow != oldValue else {
         return
       }
       let radians: CGFloat = 180 * (CGFloat.pi / 180)
-      self.arrowIconView.transform = self.flipArrow ? CGAffineTransform(rotationAngle: radians) : .identity
-      self.accessibilityHint = self.flipArrow ? LocalizableStrings.accessibilityActivateToHideAlbumList : LocalizableStrings.accessibilityActivateToShowAlbumList
+      arrowIconView.transform = flipArrow ? CGAffineTransform(rotationAngle: radians) : .identity
+      accessibilityHint = flipArrow ? LocalizableStrings.accessibilityActivateToHideAlbumList : LocalizableStrings.accessibilityActivateToShowAlbumList
     }
   }
   
@@ -64,15 +64,15 @@ final class AlbumTitleView: UIControl {
     didSet {
       guard let colors = colors else { return }
       
-      self.titleLabel.textColor = colors.label
-      self.directionLabel.textColor = colors.secondaryLabel
+      titleLabel.textColor = colors.label
+      directionLabel.textColor = colors.secondaryLabel
     }
   }
   
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -80,13 +80,13 @@ final class AlbumTitleView: UIControl {
   }
   
   private func setupView() {
-    self.addSubview(self.titleLabel)
-    self.addSubview(self.arrowIconView)
-    self.addSubview(self.directionLabel)
+    addSubview(titleLabel)
+    addSubview(arrowIconView)
+    addSubview(directionLabel)
     
-    self.isAccessibilityElement = true
-    self.accessibilityTraits = UIAccessibilityTraits.button
-    self.accessibilityHint = LocalizableStrings.accessibilityActivateToShowAlbumList
+    isAccessibilityElement = true
+    accessibilityTraits = UIAccessibilityTraits.button
+    accessibilityHint = LocalizableStrings.accessibilityActivateToShowAlbumList
   }
   
   override func layoutSubviews() {
@@ -96,29 +96,29 @@ final class AlbumTitleView: UIControl {
     
     let arrowIconOffset = CGPoint(x: 3, y: 2)
     
-    var titleLabelSize = self.titleLabel.intrinsicContentSize
+    var titleLabelSize = titleLabel.intrinsicContentSize
     titleLabelSize.width = min(titleLabelSize.width, bounds.width)
     var titleLabelOrigin = CGPoint()
     
-    var arrowIconViewSize = self.arrowIconView.intrinsicContentSize
+    var arrowIconViewSize = arrowIconView.intrinsicContentSize
     arrowIconViewSize.width = min(arrowIconViewSize.width, bounds.width)
     var arrowIconViewOrigin = CGPoint()
     
-    var directionLabelSize = self.directionLabel.intrinsicContentSize
+    var directionLabelSize = directionLabel.intrinsicContentSize
     directionLabelSize.width = min(directionLabelSize.width, bounds.width)
     var directionLabelOrigin = CGPoint()
     
-    titleLabelOrigin.x = (self.bounds.width - (titleLabelSize.width + arrowIconViewSize.width + arrowIconOffset.x)) / 2
+    titleLabelOrigin.x = (bounds.width - (titleLabelSize.width + arrowIconViewSize.width + arrowIconOffset.x)) / 2
     arrowIconViewOrigin.x = titleLabelOrigin.x + titleLabelSize.width + arrowIconOffset.x
-    directionLabelOrigin.x = (self.bounds.width - directionLabelSize.width) / 2
+    directionLabelOrigin.x = (bounds.width - directionLabelSize.width) / 2
     
-    titleLabelOrigin.y = (self.bounds.height - (titleLabelSize.height + directionLabelSize.height)) / 2
+    titleLabelOrigin.y = (bounds.height - (titleLabelSize.height + directionLabelSize.height)) / 2
     arrowIconViewOrigin.y = titleLabelOrigin.y + ((titleLabelSize.height - arrowIconViewSize.height) / 2) + arrowIconOffset.y
     directionLabelOrigin.y = titleLabelOrigin.y + titleLabelSize.height
     
-    self.titleLabel.frame = CGRect(origin: titleLabelOrigin, size: titleLabelSize)
-    self.arrowIconView.frame = CGRect(origin: arrowIconViewOrigin, size: arrowIconViewSize)
-    self.directionLabel.frame = CGRect(origin: directionLabelOrigin, size: directionLabelSize)
+    titleLabel.frame = CGRect(origin: titleLabelOrigin, size: titleLabelSize)
+    arrowIconView.frame = CGRect(origin: arrowIconViewOrigin, size: arrowIconViewSize)
+    directionLabel.frame = CGRect(origin: directionLabelOrigin, size: directionLabelSize)
   }
   
 }

--- a/Tatsi/UIElements/AlbumsTableHeaderView.swift
+++ b/Tatsi/UIElements/AlbumsTableHeaderView.swift
@@ -32,22 +32,22 @@ final internal class AlbumsTableHeaderView: UITableViewHeaderFooterView {
   
   internal var colors: TatsiColors? {
     didSet {
-      self.label.textColor = self.colors?.label ?? TatsiConfig.default.colors.label
-      self.backgroundView?.backgroundColor = self.colors?.background ?? TatsiConfig.default.colors.background
+      label.textColor = colors?.label ?? TatsiConfig.default.colors.label
+      backgroundView?.backgroundColor = colors?.background ?? TatsiConfig.default.colors.background
     }
   }
   
   internal var title: String? {
     didSet {
-      self.label.text = self.title
-      self.accessibilityLabel = self.title
+      label.text = title
+      accessibilityLabel = title
     }
   }
   
   override init(reuseIdentifier: String?) {
     super.init(reuseIdentifier: reuseIdentifier)
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -55,18 +55,18 @@ final internal class AlbumsTableHeaderView: UITableViewHeaderFooterView {
   }
   
   private func setupView() {
-    self.contentView.addSubview(self.label)
-    self.backgroundView = UIView()
-    self.backgroundView?.backgroundColor = TatsiConfig.default.colors.background
+    contentView.addSubview(label)
+    backgroundView = UIView()
+    backgroundView?.backgroundColor = TatsiConfig.default.colors.background
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     let constraints = [
-      self.label.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 8),
-      self.bottomAnchor.constraint(equalTo: self.label.bottomAnchor, constant: 4),
-      self.layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: self.label.trailingAnchor)
+      label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+      bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: 4),
+      layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: label.trailingAnchor)
     ]
     
     NSLayoutConstraint.activate(constraints)

--- a/Tatsi/UIElements/AssetTypeIconView.swift
+++ b/Tatsi/UIElements/AssetTypeIconView.swift
@@ -37,13 +37,13 @@ final internal class AssetTypeIconView: UIView {
   
   var color: UIColor = .white {
     didSet {
-      self.setNeedsDisplay()
+      setNeedsDisplay()
     }
   }
   
   var icon: Icon = .favorite {
     didSet {
-      self.setNeedsDisplay()
+      setNeedsDisplay()
     }
   }
   
@@ -52,8 +52,8 @@ final internal class AssetTypeIconView: UIView {
     
     self.icon = icon
     
-    self.isOpaque = false
-    self.backgroundColor = .clear
+    isOpaque = false
+    backgroundColor = .clear
   }
   
   required init?(coder aDecoder: NSCoder) {

--- a/Tatsi/UIElements/CameraIconView.swift
+++ b/Tatsi/UIElements/CameraIconView.swift
@@ -13,8 +13,8 @@ final internal class CameraIconView: UIView {
   
   init() {
     super.init(frame: CGRect())
-    self.backgroundColor = .clear
-    self.isOpaque = false
+    backgroundColor = .clear
+    isOpaque = false
   }
   
   required init?(coder aDecoder: NSCoder) {

--- a/Tatsi/UIElements/ChangeAlbumArrowView.swift
+++ b/Tatsi/UIElements/ChangeAlbumArrowView.swift
@@ -13,8 +13,8 @@ internal class ChangeAlbumArrowView: UIView {
   
   override init(frame: CGRect) {
     super.init(frame: frame)
-    self.backgroundColor = .clear
-    self.isOpaque = false
+    backgroundColor = .clear
+    isOpaque = false
   }
   
   required init?(coder aDecoder: NSCoder) {

--- a/Tatsi/UIElements/LocalizableStrings.swift
+++ b/Tatsi/UIElements/LocalizableStrings.swift
@@ -20,92 +20,92 @@ final internal class LocalizableStrings {
   
   /// The title at the top of the albums view
   static var albumsViewTitle: String {
-    return NSLocalizedString("tatsi-picker.view.albums.title", tableName: self.tableName, bundle: self.bundle, value: "Photos", comment: "The title at the top of the albums view")
+    return NSLocalizedString("tatsi-picker.view.albums.title", tableName: tableName, bundle: bundle, value: "Photos", comment: "The title at the top of the albums view")
   }
   
   /// The title of the back button leading to the albums view
   static var albumsViewBackButton: String {
-    return NSLocalizedString("tatsi-picker.view.albums.back-button", tableName: self.tableName, bundle: self.bundle, value: "Albums", comment: "The title of the back button leading to the albums view")
+    return NSLocalizedString("tatsi-picker.view.albums.back-button", tableName: tableName, bundle: bundle, value: "Albums", comment: "The title of the back button leading to the albums view")
   }
   
   /// The title of the hint label below the albums's name
   static var tapToChangeAlbumTitle: String {
-    return NSLocalizedString("tasti.button.change-album", tableName: self.tableName, bundle: self.bundle, value: "Tap here to change", comment: "The label that is shown below the album's name to direct the user to tap the title to change the album")
+    return NSLocalizedString("tasti.button.change-album", tableName: tableName, bundle: bundle, value: "Tap here to change", comment: "The label that is shown below the album's name to direct the user to tap the title to change the album")
   }
   
   /// The title of the user albums header on the albums view
   static var albumsViewMyAlbumsHeader: String {
-    return NSLocalizedString("tatsi-picker.view.albums.my-albums.header", tableName: self.tableName, bundle: self.bundle, value: "My Albums", comment: "The title of the user albums header on the albums view")
+    return NSLocalizedString("tatsi-picker.view.albums.my-albums.header", tableName: tableName, bundle: bundle, value: "My Albums", comment: "The title of the user albums header on the albums view")
   }
   
   /// The title of the (iCloud) shared albums header on the albums view
   static var albumsViewSharedAlbumsHeader: String {
-    return NSLocalizedString("tatsi-picker.view.albums.shared-albums.header", tableName: self.tableName, bundle: self.bundle, value: "Shared Albums", comment: "The title of the (iCloud) shared albums header on the albums view")
+    return NSLocalizedString("tatsi-picker.view.albums.shared-albums.header", tableName: tableName, bundle: bundle, value: "Shared Albums", comment: "The title of the (iCloud) shared albums header on the albums view")
   }
   
   /// The title for the message when the picker has no access to photos
   static var authorizationViewNoAccessTitle: String {
-    return NSLocalizedString("tatsi-picker.view.authorization.no-access.title", tableName: self.tableName, bundle: self.bundle, value: "Access Denied", comment: "The title for the message when the picker has no access to photos")
+    return NSLocalizedString("tatsi-picker.view.authorization.no-access.title", tableName: tableName, bundle: bundle, value: "Access Denied", comment: "The title for the message when the picker has no access to photos")
   }
   
   /// The message when the picker has no access to photo
   static var authorizationViewNoAccessMessage: String {
-    return NSLocalizedString("tatsi-picker.view.authorization.no-access.message", tableName: self.tableName, bundle: self.bundle, value: "Please allow access to photos in the Settings app", comment: "The message when the picker has no access to photos")
+    return NSLocalizedString("tatsi-picker.view.authorization.no-access.message", tableName: tableName, bundle: bundle, value: "Please allow access to photos in the Settings app", comment: "The message when the picker has no access to photos")
   }
   
   /// The button on the no access view that leads to the settings in the Settings.app
   static var authorizationViewSettingsButton: String {
-    return NSLocalizedString("tatsi-picker.view.authorization.button.settings", tableName: self.tableName, bundle: self.bundle, value: "Open Settings", comment: "The button on the no access view that leads to the settings in the Settings.app")
+    return NSLocalizedString("tatsi-picker.view.authorization.button.settings", tableName: tableName, bundle: bundle, value: "Open Settings", comment: "The button on the no access view that leads to the settings in the Settings.app")
   }
   
   /// The title for the message when the picker is requesting access to photos
   static var authorizationViewRequestingAccessTitle: String {
-    return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.title", tableName: self.tableName, bundle: self.bundle, value: "Requesting Access", comment: "The title for the message when the picker is requesting access to photos")
+    return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.title", tableName: tableName, bundle: bundle, value: "Requesting Access", comment: "The title for the message when the picker is requesting access to photos")
   }
   
   /// The message when the picker is requesting access to photos
   static var authorizationViewRequestingAccessMessage: String {
-    return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.message", tableName: self.tableName, bundle: self.bundle, value: "Tap allow to give access to your photos library", comment: "The message when the picker is requesting access to photos")
+    return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.message", tableName: tableName, bundle: bundle, value: "Tap allow to give access to your photos library", comment: "The message when the picker is requesting access to photos")
   }
   
   /// The title of the empty state when an album is empty
   static var emptyAlbumTitle: String {
-    return NSLocalizedString("tatsi-picker.view.album.empty.title", tableName: self.tableName, bundle: self.bundle, value: "No Photos or Videos", comment: "The title of the empty state when an album is empty")
+    return NSLocalizedString("tatsi-picker.view.album.empty.title", tableName: tableName, bundle: bundle, value: "No Photos or Videos", comment: "The title of the empty state when an album is empty")
   }
   
   /// The message of the empty state when an album is empty
   static var emptyAlbumMessage: String {
-    return NSLocalizedString("tatsi-picker.view.album.empty.message", tableName: self.tableName, bundle: self.bundle, value: "Save some photos or videos to your device", comment: "The message of the empty state when an album is empty")
+    return NSLocalizedString("tatsi-picker.view.album.empty.message", tableName: tableName, bundle: bundle, value: "Save some photos or videos to your device", comment: "The message of the empty state when an album is empty")
   }
   
   /// The title of the empty state when the album is loading it's assets
   static var albumLoading: String {
-    return NSLocalizedString("tatsi-picker.view.album.loading.title", tableName: self.tableName, bundle: self.bundle, value: "Loading...", comment: "The title of the empty state when the album is loading it's assets.")
+    return NSLocalizedString("tatsi-picker.view.album.loading.title", tableName: tableName, bundle: bundle, value: "Loading...", comment: "The title of the empty state when the album is loading it's assets.")
   }
   
   /// The title of the camera button
   static var cameraButtonTitle: String {
-    return NSLocalizedString("tatsi-picker.button.camera.title", tableName: self.tableName, bundle: self.bundle, value: "Camera", comment: "The title of the camera button")
+    return NSLocalizedString("tatsi-picker.button.camera.title", tableName: tableName, bundle: bundle, value: "Camera", comment: "The title of the camera button")
   }
   
   /// The message that the user is alerted of when the selection limit has been reached
   static var accessibilityAlertSelectionLimitReached: String {
-    return NSLocalizedString("tatsi-picker.accessibility.selection-limit-reached", tableName: self.tableName, bundle: self.bundle, value: "The max number of assets has been selected", comment: "The message that the user is alerted of when the selection limit has been reached")
+    return NSLocalizedString("tatsi-picker.accessibility.selection-limit-reached", tableName: tableName, bundle: bundle, value: "The max number of assets has been selected", comment: "The message that the user is alerted of when the selection limit has been reached")
   }
   
   /// The image count in an album, for accessibility users
   static var accessibilityAlbumImagesCount: String {
-    return NSLocalizedString("tatsi-picker.accessibility.images-count", tableName: self.tableName, bundle: self.bundle, value: "%d Images", comment: "The image count in an album, for accessibility users")
+    return NSLocalizedString("tatsi-picker.accessibility.images-count", tableName: tableName, bundle: bundle, value: "%d Images", comment: "The image count in an album, for accessibility users")
   }
   
   /// The accessibility hint the user gets on the album switcher to close/hide the album list
   static var accessibilityActivateToHideAlbumList: String {
-    return NSLocalizedString("tatsi-picker.accessibility.activate-to-hide-album-list", tableName: self.tableName, bundle: self.bundle, value: "Activate to hide album list", comment: "The accessibility hint the user gets on the album switcher")
+    return NSLocalizedString("tatsi-picker.accessibility.activate-to-hide-album-list", tableName: tableName, bundle: bundle, value: "Activate to hide album list", comment: "The accessibility hint the user gets on the album switcher")
   }
   
   /// The accessibility hint the user gets on the album switcher to show/open the album list
   static var accessibilityActivateToShowAlbumList: String {
-    return NSLocalizedString("tatsi-picker.accessibility.activate-to-show-album-list", tableName: self.tableName, bundle: self.bundle, value: "Activate to show album list", comment: "The accessibility hint the user gets on the album switcher")
+    return NSLocalizedString("tatsi-picker.accessibility.activate-to-show-album-list", tableName: tableName, bundle: bundle, value: "Activate to show album list", comment: "The accessibility hint the user gets on the album switcher")
   }
   
 }

--- a/Tatsi/UIElements/SelectionIconView.swift
+++ b/Tatsi/UIElements/SelectionIconView.swift
@@ -13,9 +13,9 @@ final internal class SelectionIconView: UIView {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    self.backgroundColor = .clear
-    self.isOpaque = false
-    self.clipsToBounds = false
+    backgroundColor = .clear
+    isOpaque = false
+    clipsToBounds = false
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -23,7 +23,7 @@ final internal class SelectionIconView: UIView {
   }
   
   override func draw(_ rect: CGRect) {
-    self.drawIcon()
+    drawIcon()
   }
   
   override var intrinsicContentSize: CGSize {
@@ -50,7 +50,7 @@ final internal class SelectionIconView: UIView {
     
     //// Fill Drawing
     let fillPath = UIBezierPath(ovalIn: CGRect(x: 1, y: 1, width: 22, height: 22))
-    self.tintColor.setFill()
+    tintColor.setFill()
     fillPath.fill()
     
     //// Checkmark Drawing

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -38,7 +38,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
   weak var delegate: AlbumsViewControllerDelegate?
   
   override var preferredStatusBarStyle: UIStatusBarStyle {
-    return self.config?.preferredStatusBarStyle ?? .default
+    return config?.preferredStatusBarStyle ?? .default
   }
   
   // MARK: - Private Properties
@@ -87,38 +87,38 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    let cancelButtonItem = self.pickerViewController?.customCancelButtonItem() ?? UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(AlbumsViewController.cancel(_:)))
+    let cancelButtonItem = pickerViewController?.customCancelButtonItem() ?? UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(AlbumsViewController.cancel(_:)))
     cancelButtonItem.target = self
     cancelButtonItem.action = #selector(cancel(_:))
     cancelButtonItem.accessibilityIdentifier = "tatsi.button.cancel"
-    cancelButtonItem.tintColor = self.config?.colors.link ?? TatsiConfig.default.colors.link
-    self.navigationItem.rightBarButtonItem = cancelButtonItem
+    cancelButtonItem.tintColor = config?.colors.link ?? TatsiConfig.default.colors.link
+    navigationItem.rightBarButtonItem = cancelButtonItem
     
-    self.navigationItem.backBarButtonItem?.accessibilityIdentifier = "tatsi.button.albums"
+    navigationItem.backBarButtonItem?.accessibilityIdentifier = "tatsi.button.albums"
     
-    self.title = LocalizableStrings.albumsViewTitle
+    title = LocalizableStrings.albumsViewTitle
     
-    self.tableView.register(AlbumTableViewCell.self, forCellReuseIdentifier: AlbumTableViewCell.reuseIdentifier)
-    self.tableView.register(AlbumsTableHeaderView.self, forHeaderFooterViewReuseIdentifier: AlbumsTableHeaderView.reuseIdentifier)
-    self.tableView.rowHeight = 90
-    self.tableView.separatorInset = UIEdgeInsets(top: 0, left: -10, bottom: 0, right: 0)
-    self.tableView.separatorStyle = .none
-    self.tableView.backgroundColor = self.config?.colors.background ?? TatsiConfig.default.colors.background
+    tableView.register(AlbumTableViewCell.self, forCellReuseIdentifier: AlbumTableViewCell.reuseIdentifier)
+    tableView.register(AlbumsTableHeaderView.self, forHeaderFooterViewReuseIdentifier: AlbumsTableHeaderView.reuseIdentifier)
+    tableView.rowHeight = 90
+    tableView.separatorInset = UIEdgeInsets(top: 0, left: -10, bottom: 0, right: 0)
+    tableView.separatorStyle = .none
+    tableView.backgroundColor = config?.colors.background ?? TatsiConfig.default.colors.background
     
-    self.tableView.accessibilityIdentifier = "tatsi.tableView.albums"
+    tableView.accessibilityIdentifier = "tatsi.tableView.albums"
     
-    self.startLoadingAlbums()
+    startLoadingAlbums()
   }
   
   // MARK: - Accessibility
   
   public override func accessibilityPerformEscape() -> Bool {
-    if self.config?.singleViewMode == true {
+    if config?.singleViewMode == true {
       return false
     } else {
-      self.cancelPicking()
-      if self.pickerViewController?.pickerDelegate == nil {
-        self.dismiss(animated: true, completion: nil)
+      cancelPicking()
+      if pickerViewController?.pickerDelegate == nil {
+        dismiss(animated: true, completion: nil)
       }
       return true
     }
@@ -128,36 +128,36 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
   
   fileprivate func startLoadingAlbums() {
     var newCategories = [AlbumCategory]()
-    let smartAlbums = self.fetchSmartAlbums()
+    let smartAlbums = fetchSmartAlbums()
     if !smartAlbums.isEmpty {
       newCategories.append(AlbumCategory(headerTitle: nil, albums: smartAlbums))
     }
     
-    let userAlbums = self.fetchUserAlbums()
+    let userAlbums = fetchUserAlbums()
     if !userAlbums.isEmpty {
       newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewMyAlbumsHeader, albums: userAlbums))
     }
     
-    if self.config?.showSharedAlbums == true {
-      let sharedAlbums = self.fetchSharedAlbums()
+    if config?.showSharedAlbums == true {
+      let sharedAlbums = fetchSharedAlbums()
       if !sharedAlbums.isEmpty {
         newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewSharedAlbumsHeader, albums: sharedAlbums))
       }
     }
-    self.categories = newCategories
+    categories = newCategories
   }
   
   fileprivate func fetchSmartAlbums() -> [PHAssetCollection] {
     let collectionResults = PHAssetCollection.fetchAssetCollections(with: PHAssetCollectionType.smartAlbum, subtype: PHAssetCollectionSubtype.albumRegular, options: nil)
     var collections = [PHAssetCollection]()
-    collectionResults.enumerateObjects({ (collection, _, _) in
+    collectionResults.enumerateObjects({ collection, _, _ in
       guard self.config?.isCollectionAllowed(collection) == true else {
         return
       }
       collections.append(collection)
     })
     collections.sort { (collection1, collection2) -> Bool in
-      guard let index1 = self.smartAlbumSortingOrder.firstIndex(of: collection1.assetCollectionSubtype), let index2 = self.smartAlbumSortingOrder.firstIndex(of: collection2.assetCollectionSubtype) else {
+      guard let index1 = smartAlbumSortingOrder.firstIndex(of: collection1.assetCollectionSubtype), let index2 = smartAlbumSortingOrder.firstIndex(of: collection2.assetCollectionSubtype) else {
         return true
       }
       return index1 < index2
@@ -168,7 +168,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
   fileprivate func fetchUserAlbums() -> [PHAssetCollection] {
     let collectionResults = PHCollectionList.fetchTopLevelUserCollections(with: nil)
     var collections = [PHAssetCollection]()
-    collectionResults.enumerateObjects({ (collection, _, _) in
+    collectionResults.enumerateObjects({ collection, _, _ in
       guard let assetCollection = collection as? PHAssetCollection, self.config?.isCollectionAllowed(collection) == true else {
         return
       }
@@ -186,7 +186,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
   fileprivate func fetchSharedAlbums() -> [PHAssetCollection] {
     let collectionResults = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumCloudShared, options: nil)
     var collections = [PHAssetCollection]()
-    collectionResults.enumerateObjects({ (collection, _, _) in
+    collectionResults.enumerateObjects({ collection, _, _ in
       collections.append(collection)
     })
     collections.sort { (collection1, collection2) -> Bool in
@@ -201,20 +201,20 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
   // MARK: - Actions
   
   @objc fileprivate func cancel(_ sender: AnyObject) {
-    self.cancelPicking()
+    cancelPicking()
   }
   
   // MARK: - Helpers
   
   fileprivate func category(for section: Int) -> AlbumCategory? {
-    guard section < self.categories.count else {
+    guard section < categories.count else {
       return nil
     }
-    return self.categories[section]
+    return categories[section]
   }
   
   fileprivate func album(for indexPath: IndexPath) -> PHAssetCollection? {
-    guard let category = self.category(for: indexPath.section), indexPath.row < category.albums.count else {
+    guard let category = category(for: indexPath.section), indexPath.row < category.albums.count else {
       return nil
     }
     return category.albums[indexPath.row]
@@ -227,21 +227,21 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
 extension AlbumsViewController {
   
   override func numberOfSections(in tableView: UITableView) -> Int {
-    return self.categories.count
+    return categories.count
   }
   
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return self.category(for: section)?.albums.count ?? 0
+    return category(for: section)?.albums.count ?? 0
   }
   
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     guard let cell = tableView.dequeueReusableCell(withIdentifier: AlbumTableViewCell.reuseIdentifier, for: indexPath) as? AlbumTableViewCell else {
       fatalError("AlbumTableViewCell probably not registered")
     }
-    cell.album = self.album(for: indexPath)
-    cell.reloadContents(with: self.config?.assetFetchOptions())
-    cell.accessoryType = (self.config?.singleViewMode ?? false) ? .none : .disclosureIndicator
-    cell.colors = self.config?.colors
+    cell.album = album(for: indexPath)
+    cell.reloadContents(with: config?.assetFetchOptions())
+    cell.accessoryType = (config?.singleViewMode ?? false) ? .none : .disclosureIndicator
+    cell.colors = config?.colors
     return cell
   }
   
@@ -252,32 +252,32 @@ extension AlbumsViewController {
 extension AlbumsViewController {
   
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    guard let album = self.album(for: indexPath) else {
+    guard let album = album(for: indexPath) else {
       return
     }
-    if let delegate = self.delegate {
+    if let delegate = delegate {
       delegate.albumsViewController(self, didSelectAlbum: album)
     } else {
       let gridViewController = AssetsGridViewController(album: album)
-      self.navigationController?.pushViewController(gridViewController, animated: true)
+      navigationController?.pushViewController(gridViewController, animated: true)
     }
-    self.didSelectCollection(album)
+    didSelectCollection(album)
   }
   
   override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard let category = self.category(for: section) else {
+    guard let category = category(for: section) else {
       return nil
     }
     guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: AlbumsTableHeaderView.reuseIdentifier) as? AlbumsTableHeaderView else {
       fatalError("AlbumsTableHeaderView probably not registered")
     }
     headerView.title = category.headerTitle
-    headerView.colors = self.config?.colors
+    headerView.colors = config?.colors
     return headerView
   }
   
   override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    guard self.category(for: section)?.headerTitle != nil else {
+    guard category(for: section)?.headerTitle != nil else {
       return 0
     }
     return AlbumsTableHeaderView.height

--- a/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
+++ b/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
@@ -46,7 +46,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
   }()
   
   lazy private var labelsStackView: UIStackView = {
-    let stackView = UIStackView(arrangedSubviews: [self.titleLabel, self.countLabel])
+    let stackView = UIStackView(arrangedSubviews: [titleLabel, countLabel])
     stackView.axis = .vertical
     stackView.spacing = 2
     stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -55,15 +55,15 @@ final internal class AlbumTableViewCell: UITableViewCell {
   
   var album: PHAssetCollection? {
     didSet {
-      self.albumChanged = self.album != oldValue
+      albumChanged = album != oldValue
     }
   }
   
   var colors: TatsiColors? {
     didSet {
-      self.backgroundColor = self.colors?.background ?? TatsiConfig.default.colors.background
-      self.titleLabel.textColor = self.colors?.label ?? TatsiConfig.default.colors.label
-      self.countLabel.textColor = self.colors?.secondaryLabel ?? TatsiConfig.default.colors.secondaryLabel
+      backgroundColor = colors?.background ?? TatsiConfig.default.colors.background
+      titleLabel.textColor = colors?.label ?? TatsiConfig.default.colors.label
+      countLabel.textColor = colors?.secondaryLabel ?? TatsiConfig.default.colors.secondaryLabel
     }
   }
   
@@ -72,7 +72,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -80,68 +80,67 @@ final internal class AlbumTableViewCell: UITableViewCell {
   }
   
   private func setupView() {
-    self.contentView.addSubview(self.albumImageView)
-    self.contentView.addSubview(self.labelsStackView)
+    contentView.addSubview(albumImageView)
+    contentView.addSubview(labelsStackView)
     
-    self.accessibilityIdentifier = "tatsi.cell.album"
+    accessibilityIdentifier = "tatsi.cell.album"
     
-    self.accessoryType = .disclosureIndicator
+    accessoryType = .disclosureIndicator
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     
     let constraints = [
-      self.albumImageView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 8),
-      self.layoutMarginsGuide.bottomAnchor.constraint(equalTo: self.albumImageView.bottomAnchor),
+      albumImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+      layoutMarginsGuide.bottomAnchor.constraint(equalTo: albumImageView.bottomAnchor),
       
-      self.labelsStackView.centerYAnchor.constraint(equalTo: self.albumImageView.centerYAnchor),
-      self.labelsStackView.leadingAnchor.constraint(equalTo: self.albumImageView.trailingAnchor, constant: 16),
-      self.layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: self.labelsStackView.trailingAnchor)
-      
+      labelsStackView.centerYAnchor.constraint(equalTo: albumImageView.centerYAnchor),
+      labelsStackView.leadingAnchor.constraint(equalTo: albumImageView.trailingAnchor, constant: 16),
+      layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: labelsStackView.trailingAnchor)
     ]
     
     NSLayoutConstraint.activate(constraints)
   }
   
   func reloadContents(with options: PHFetchOptions?) {
-    guard self.albumChanged else {
+    guard albumChanged else {
       return
     }
-    self.albumChanged = false
+    albumChanged = false
     
-    self.titleLabel.text = self.album?.localizedTitle
+    titleLabel.text = album?.localizedTitle
     
     let fetchOptions = options
-    let count = self.album?.estimatedAssetCount ?? 0
+    let count = album?.estimatedAssetCount ?? 0
     
     //First we set a temporary count that might not represent the actual count
     if count != NSNotFound {
-      self.countLabel.text = AlbumTableViewCell.numberFormatter.string(from: NSNumber(value: count))
+      countLabel.text = AlbumTableViewCell.numberFormatter.string(from: NSNumber(value: count))
     } else {
-      self.countLabel.text = "0"
+      countLabel.text = "0"
     }
     
-    self.accessibilityLabel = self.album?.localizedTitle
-    self.accessibilityValue = String(format: LocalizableStrings.accessibilityAlbumImagesCount, locale: nil, arguments: [count])
+    accessibilityLabel = album?.localizedTitle
+    accessibilityValue = String(format: LocalizableStrings.accessibilityAlbumImagesCount, locale: nil, arguments: [count])
     
-    self.album?.fetchNumberOfItems(for: fetchOptions, completionHandler: { [weak self] (count, collection) in
+    album?.fetchNumberOfItems(for: fetchOptions, completionHandler: { [weak self] (count, collection) in
       guard let strongSelf = self, collection == strongSelf.album else {
         return
       }
-      self?.countLabel.text = AlbumTableViewCell.numberFormatter.string(from: NSNumber(value: count))
-      self?.accessibilityValue = String(format: LocalizableStrings.accessibilityAlbumImagesCount, locale: nil, arguments: [count])
+      strongSelf.countLabel.text = AlbumTableViewCell.numberFormatter.string(from: NSNumber(value: count))
+      strongSelf.accessibilityValue = String(format: LocalizableStrings.accessibilityAlbumImagesCount, locale: nil, arguments: [count])
     })
     
     
-    self.albumImageView.imageView.contentMode = UIView.ContentMode.center
-    self.albumImageView.image = nil
+    albumImageView.imageView.contentMode = UIView.ContentMode.center
+    albumImageView.image = nil
     
     guard let album = self.album, !album.isRecentlyDeletedCollection && album.assetCollectionSubtype != .smartAlbumAllHidden else {
       return
     }
-    album.loadPreviewImage(self.albumImageView.preferredImageSize, fetchOptions: fetchOptions, completionHandler: { [weak self] (image, _) in
+    album.loadPreviewImage(albumImageView.preferredImageSize, fetchOptions: fetchOptions, completionHandler: { [weak self] (image, _) in
       if let image = image {
         self?.albumImageView.imageView.contentMode = UIView.ContentMode.scaleAspectFill
         self?.albumImageView.image = image

--- a/Tatsi/Views/Assets Grid/Cells/AssetCollectionViewCell.swift
+++ b/Tatsi/Views/Assets Grid/Cells/AssetCollectionViewCell.swift
@@ -19,10 +19,10 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
   
   internal var imageSize: CGSize = CGSize(width: 100, height: 100) {
     didSet {
-      guard self.imageSize != oldValue else {
+      guard imageSize != oldValue else {
         return
       }
-      self.shouldUpdateImage = true
+      shouldUpdateImage = true
     }
   }
   
@@ -30,12 +30,12 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
   
   internal var asset: PHAsset? {
     didSet {
-      self.metadataView.asset = self.asset
-      guard self.asset != oldValue || self.imageView.image == nil else {
+      metadataView.asset = asset
+      guard asset != oldValue || imageView.image == nil else {
         return
       }
-      self.accessibilityLabel = asset?.accessibilityLabel
-      self.shouldUpdateImage = true
+      accessibilityLabel = asset?.accessibilityLabel
+      shouldUpdateImage = true
     }
   }
   
@@ -62,7 +62,7 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
     view.isHidden = true
     view.backgroundColor = UIColor.white.withAlphaComponent(0.4)
     
-    view.addSubview(self.iconView)
+    view.addSubview(iconView)
     view.bottomAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 3).isActive = true
     view.trailingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 3).isActive = true
     
@@ -78,7 +78,7 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -86,74 +86,74 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
   }
   
   private func setupView() {
-    self.contentView.addSubview(self.imageView)
-    self.contentView.addSubview(self.metadataView)
-    self.contentView.addSubview(self.selectedOverlay)
+    contentView.addSubview(imageView)
+    contentView.addSubview(metadataView)
+    contentView.addSubview(selectedOverlay)
     
-    self.accessibilityIdentifier = "tatsi.cell.asset"
-    self.accessibilityTraits = UIAccessibilityTraits.image
-    self.isAccessibilityElement = true
+    accessibilityIdentifier = "tatsi.cell.asset"
+    accessibilityTraits = UIAccessibilityTraits.image
+    isAccessibilityElement = true
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     let constraints = [
-      self.imageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
-      self.imageView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
-      self.contentView.bottomAnchor.constraint(equalTo: self.imageView.bottomAnchor),
-      self.contentView.trailingAnchor.constraint(equalTo: self.imageView.trailingAnchor),
+      imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+      imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      contentView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
+      contentView.trailingAnchor.constraint(equalTo: imageView.trailingAnchor),
       
-      self.selectedOverlay.topAnchor.constraint(equalTo: self.contentView.topAnchor),
-      self.selectedOverlay.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
-      self.contentView.bottomAnchor.constraint(equalTo: self.selectedOverlay.bottomAnchor),
-      self.contentView.trailingAnchor.constraint(equalTo: self.selectedOverlay.trailingAnchor),
+      selectedOverlay.topAnchor.constraint(equalTo: contentView.topAnchor),
+      selectedOverlay.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      contentView.bottomAnchor.constraint(equalTo: selectedOverlay.bottomAnchor),
+      contentView.trailingAnchor.constraint(equalTo: selectedOverlay.trailingAnchor),
       
-      self.metadataView.leftAnchor.constraint(equalTo: self.contentView.leftAnchor),
-      self.contentView.bottomAnchor.constraint(equalTo: self.metadataView.bottomAnchor),
-      self.contentView.rightAnchor.constraint(equalTo: self.metadataView.rightAnchor)
+      metadataView.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+      contentView.bottomAnchor.constraint(equalTo: metadataView.bottomAnchor),
+      contentView.rightAnchor.constraint(equalTo: metadataView.rightAnchor)
     ]
     
     NSLayoutConstraint.activate(constraints)
   }
   
   internal func reloadContents() {
-    guard self.shouldUpdateImage else {
+    guard shouldUpdateImage else {
       return
     }
-    self.shouldUpdateImage = false
+    shouldUpdateImage = false
     
     // Set the correct checkmark color
-    self.iconView.tintColor = self.colors?.checkMark ?? self.colors?.link
+    iconView.tintColor = colors?.checkMark ?? colors?.link
     
-    self.startLoadingImage()
+    startLoadingImage()
   }
   
   override func prepareForReuse() {
     super.prepareForReuse()
     
-    self.imageView.image = nil
+    imageView.image = nil
     
-    if let currentRequest = self.currentRequest {
-      let imageManager = self.imageManager ?? PHImageManager.default()
+    if let currentRequest = currentRequest {
+      let imageManager = imageManager ?? PHImageManager.default()
       imageManager.cancelImageRequest(currentRequest)
     }
     
   }
   
   fileprivate func startLoadingImage() {
-    self.imageView.image = nil
-    guard let asset = self.asset else {
+    imageView.image = nil
+    guard let asset = asset else {
       return
     }
-    let imageManager = self.imageManager ?? PHImageManager.default()
+    let imageManager = imageManager ?? PHImageManager.default()
     
     let requestOptions = PHImageRequestOptions()
     requestOptions.resizeMode = PHImageRequestOptionsResizeMode.fast
     requestOptions.isSynchronous = false
     
-    self.imageView.contentMode = UIView.ContentMode.center
-    self.imageView.image = nil
+    imageView.contentMode = UIView.ContentMode.center
+    imageView.image = nil
     DispatchQueue.global(qos: .userInteractive).async { [weak self] in
       autoreleasepool {
         let scale = UIScreen.main.scale > 2 ? 2 : UIScreen.main.scale
@@ -177,7 +177,7 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
   
   override var isSelected: Bool {
     didSet {
-      self.selectedOverlay.isHidden = !self.isSelected
+      selectedOverlay.isHidden = !isSelected
     }
   }
 }

--- a/Tatsi/Views/Assets Grid/Cells/CameraCollectionViewCell.swift
+++ b/Tatsi/Views/Assets Grid/Cells/CameraCollectionViewCell.swift
@@ -23,7 +23,7 @@ final internal class CameraCollectionViewCell: UICollectionViewCell {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -31,21 +31,21 @@ final internal class CameraCollectionViewCell: UICollectionViewCell {
   }
   
   private func setupView() {
-    self.contentView.addSubview(self.iconView)
-    self.contentView.backgroundColor = UIColor.lightGray
+    contentView.addSubview(iconView)
+    contentView.backgroundColor = UIColor.lightGray
     
-    self.accessibilityIdentifier = "tatsi.cell.camera"
-    self.accessibilityLabel = LocalizableStrings.cameraButtonTitle
-    self.accessibilityTraits = UIAccessibilityTraits.button
-    self.isAccessibilityElement = true
+    accessibilityIdentifier = "tatsi.cell.camera"
+    accessibilityLabel = LocalizableStrings.cameraButtonTitle
+    accessibilityTraits = UIAccessibilityTraits.button
+    isAccessibilityElement = true
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     let constraints = [
-      self.iconView.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
-      self.iconView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor)
+      iconView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+      iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
     ]
     
     NSLayoutConstraint.activate(constraints)

--- a/Tatsi/Views/Assets Grid/UIElements/AssetMetadataView.swift
+++ b/Tatsi/Views/Assets Grid/UIElements/AssetMetadataView.swift
@@ -31,27 +31,27 @@ final internal class AssetMetadataView: UIView {
   /// The asset the meta data should be displayed for.
   var asset: PHAsset? {
     didSet {
-      guard let asset = self.asset else {
-        self.isHidden = true
+      guard let asset = asset else {
+        isHidden = true
         return
       }
-      self.timeLabel.isHidden = asset.duration <= 0 || !self.showDuration
-      self.timeLabel.text = self.string(from: asset.duration)
+      timeLabel.isHidden = asset.duration <= 0 || !showDuration
+      timeLabel.text = string(from: asset.duration)
       
-      self.iconView.isHidden = !asset.isFavorite
-      self.iconView.icon = .favorite
+      iconView.isHidden = !asset.isFavorite
+      iconView.icon = .favorite
       
-      self.isHidden = self.timeLabel.isHidden && self.iconView.isHidden
+      isHidden = timeLabel.isHidden && iconView.isHidden
     }
   }
   
   init() {
     super.init(frame: CGRect())
     
-    self.isOpaque = false
-    self.backgroundColor = .clear
+    isOpaque = false
+    backgroundColor = .clear
     
-    self.setupView()
+    setupView()
   }
   
   required init?(coder aDecoder: NSCoder) {
@@ -59,20 +59,20 @@ final internal class AssetMetadataView: UIView {
   }
   
   private func setupView() {
-    self.addSubview(self.iconView)
-    self.addSubview(self.timeLabel)
+    addSubview(iconView)
+    addSubview(timeLabel)
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     let constraints = [
-      self.iconView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      self.iconView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 5),
+      iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+      iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
       
-      self.timeLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      self.timeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: self.iconView.trailingAnchor, constant: 8),
-      self.trailingAnchor.constraint(equalTo: self.timeLabel.trailingAnchor, constant: 6)
+      timeLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+      timeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: iconView.trailingAnchor, constant: 8),
+      trailingAnchor.constraint(equalTo: timeLabel.trailingAnchor, constant: 6)
     ]
     
     NSLayoutConstraint.activate(constraints)

--- a/Tatsi/Views/AuthorizationViewController.swift
+++ b/Tatsi/Views/AuthorizationViewController.swift
@@ -16,7 +16,7 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
     label.numberOfLines = 0
     label.textAlignment = .center
     label.font = UIFont.preferredFont(forTextStyle: .title2)
-    label.textColor = self.config?.colors.label ?? TatsiConfig.default.colors.label
+    label.textColor = config?.colors.label ?? TatsiConfig.default.colors.label
     label.translatesAutoresizingMaskIntoConstraints = false
     return label
   }()
@@ -26,7 +26,7 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
     label.numberOfLines = 0
     label.textAlignment = .center
     label.font = UIFont.preferredFont(forTextStyle: .body)
-    label.textColor = self.config?.colors.secondaryLabel ?? TatsiConfig.default.colors.secondaryLabel
+    label.textColor = config?.colors.secondaryLabel ?? TatsiConfig.default.colors.secondaryLabel
     label.translatesAutoresizingMaskIntoConstraints = false
     return label
   }()
@@ -38,13 +38,13 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
     button.translatesAutoresizingMaskIntoConstraints = false
     button.accessibilityIdentifier = "tatsi.button.openSettings"
     
-    let color = self.config?.colors.link ?? TatsiConfig.default.colors.link
+    let color = config?.colors.link ?? TatsiConfig.default.colors.link
     button.setTitleColor(color, for: .normal)
     return button
   }()
   
   lazy private var stackView: UIStackView = {
-    let stackView = UIStackView(arrangedSubviews: [self.titleLabel, self.messageLabel, self.settingsButton])
+    let stackView = UIStackView(arrangedSubviews: [titleLabel, messageLabel, settingsButton])
     stackView.axis = .vertical
     stackView.spacing = 10
     stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -53,32 +53,32 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
   }()
   
   override var preferredStatusBarStyle: UIStatusBarStyle {
-    return self.config?.preferredStatusBarStyle ?? .default
+    return config?.preferredStatusBarStyle ?? .default
   }
   
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    self.view.backgroundColor = self.config?.colors.background ?? TatsiConfig.default.colors.background
+    view.backgroundColor = config?.colors.background ?? TatsiConfig.default.colors.background
     
-    self.setupView()
+    setupView()
   }
   
   private func setupView() {
-    self.view.addSubview(self.stackView)
+    view.addSubview(stackView)
     
-    self.reloadContents()
+    reloadContents()
     
-    self.setupConstraints()
+    setupConstraints()
   }
   
   private func setupConstraints() {
     let constraints = [
-      self.stackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-      self.stackView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
-      self.stackView.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor),
-      self.view.trailingAnchor.constraint(greaterThanOrEqualTo: self.stackView.trailingAnchor),
-      self.stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 200)
+      stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      stackView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
+      view.trailingAnchor.constraint(greaterThanOrEqualTo: stackView.trailingAnchor),
+      stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 200)
     ]
     
     NSLayoutConstraint.activate(constraints)
@@ -101,13 +101,13 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
   private func reloadContents() {
     switch PHPhotoLibrary.authorizationStatus() {
     case .notDetermined:
-      self.titleLabel.text = LocalizableStrings.authorizationViewRequestingAccessTitle
-      self.messageLabel.text = LocalizableStrings.authorizationViewRequestingAccessMessage
-      self.settingsButton.isHidden = true
+      titleLabel.text = LocalizableStrings.authorizationViewRequestingAccessTitle
+      messageLabel.text = LocalizableStrings.authorizationViewRequestingAccessMessage
+      settingsButton.isHidden = true
     case .denied, .restricted:
-      self.titleLabel.text = LocalizableStrings.authorizationViewNoAccessTitle
-      self.messageLabel.text = LocalizableStrings.authorizationViewNoAccessMessage
-      self.settingsButton.isHidden = false
+      titleLabel.text = LocalizableStrings.authorizationViewNoAccessTitle
+      messageLabel.text = LocalizableStrings.authorizationViewNoAccessMessage
+      settingsButton.isHidden = false
     default:
       break
     }

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -18,7 +18,7 @@ final public class TatsiPickerViewController: UINavigationController {
   public weak var pickerDelegate: TatsiPickerViewControllerDelegate?
   
   override public var preferredStatusBarStyle: UIStatusBarStyle {
-    return self.config.preferredStatusBarStyle
+    return config.preferredStatusBarStyle
   }
   
   // MARK: - Initializers
@@ -30,7 +30,7 @@ final public class TatsiPickerViewController: UINavigationController {
     navigationBar.barTintColor = config.colors.background
     navigationBar.tintColor = config.colors.link
     
-    self.setIntialViewController()
+    setIntialViewController()
   }
   
   required public init?(coder aDecoder: NSCoder) {
@@ -45,7 +45,7 @@ final public class TatsiPickerViewController: UINavigationController {
       //Authorized, show the album view or the album detail view.
       var album: PHAssetCollection?
       let userLibrary = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: nil).firstObject
-      switch self.config.firstView {
+      switch config.firstView {
       case .userLibrary:
         album = userLibrary
       case .album(let collection):
@@ -53,15 +53,15 @@ final public class TatsiPickerViewController: UINavigationController {
       default:
         break
       }
-      if let initialAlbum = album ?? userLibrary, self.config.singleViewMode {
-        self.viewControllers = [AssetsGridViewController(album: initialAlbum)]
+      if let initialAlbum = album ?? userLibrary, config.singleViewMode {
+        viewControllers = [AssetsGridViewController(album: initialAlbum)]
       } else {
-        self.showAlbumViewController(with: album)
+        showAlbumViewController(with: album)
       }
       
     case .denied, .notDetermined, .restricted:
       // Not authorized, show the view to give access
-      self.viewControllers = [AuthorizationViewController()]
+      viewControllers = [AuthorizationViewController()]
     @unknown default:
       assertionFailure("Unknown authorization status detected.")
     }
@@ -69,18 +69,18 @@ final public class TatsiPickerViewController: UINavigationController {
   
   private func showAlbumViewController(with collection: PHAssetCollection?) {
     if let collection = collection {
-      self.viewControllers = [AlbumsViewController(), AssetsGridViewController(album: collection)]
+      viewControllers = [AlbumsViewController(), AssetsGridViewController(album: collection)]
     } else {
-      self.viewControllers = [AlbumsViewController()]
+      viewControllers = [AlbumsViewController()]
     }
   }
   
   internal func customCancelButtonItem() -> UIBarButtonItem? {
-    return self.pickerDelegate?.cancelBarButtonItem(for: self)
+    return pickerDelegate?.cancelBarButtonItem(for: self)
   }
   
   internal func customDoneButtonItem() -> UIButton? {
-    return self.pickerDelegate?.doneBarButtonItem(for: self)
+    return pickerDelegate?.doneBarButtonItem(for: self)
   }
   
 }

--- a/TatsiTests/PHAssetCollectionExtensionsTests.swift
+++ b/TatsiTests/PHAssetCollectionExtensionsTests.swift
@@ -26,7 +26,7 @@ final class PHAssetCollectionExtensionsTests: TatsiTestCase {
   func testContainsRecentlyDeleted() {
     var foundRecentlyDeleted = false
     let collections = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .albumRegular, options: nil)
-    collections.enumerateObjects({ (assetCollection, _, _) in
+    collections.enumerateObjects({ assetCollection, _, _ in
       if assetCollection.isRecentlyDeletedCollection {
         foundRecentlyDeleted = true
       }
@@ -39,7 +39,7 @@ final class PHAssetCollectionExtensionsTests: TatsiTestCase {
   func testContainsUserLibrary() {
     var foundUserLibrary = false
     let collections = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: nil)
-    collections.enumerateObjects({ (assetCollection, _, _) in
+    collections.enumerateObjects({ assetCollection, _, _ in
       if assetCollection.isUserLibrary {
         foundUserLibrary = true
       }

--- a/TatsiTests/TatsiTestCase.swift
+++ b/TatsiTests/TatsiTestCase.swift
@@ -88,7 +88,7 @@ class TatsiTestCase: XCTestCase {
       self.addedAssetIdentifiers.append(contentsOf: assetIdentifiers)
       let result = PHAsset.fetchAssets(withLocalIdentifiers: assetIdentifiers, options: nil)
       var assets = [PHAsset]()
-      result.enumerateObjects({ (asset, _, _) in
+      result.enumerateObjects({ asset, _, _ in
         assets.append(asset)
       })
       if let collection = collection {
@@ -115,7 +115,7 @@ class TatsiTestCase: XCTestCase {
       }
       var collection: PHAssetCollection?
       let result = PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: [localIdentifier], options: nil)
-      result.enumerateObjects({ (assetCollection, _, _) in
+      result.enumerateObjects({ assetCollection, _, _ in
         collection = assetCollection
       })
       return collection


### PR DESCRIPTION
`self` does not need to be referenced within a class unless you are directly referencing a value that is named the same as a parameter within an instance function.


Example:

**Preferred**
```swift

func doSomethingWith(stuff: String) {
 self.stuff = stuff
}
```

**Not Preferred**

```swift

class SomeClass: SomeClassProtocol {
  var stuffy: String


  init(stuff: String) {
    self.stuffy = self // wrong usage.
    stuffy = self // correct usage.
  }
}
```