### PR TITLE
Update title based on asset selection.

### DIFF
--- a/Example/Views/ViewController.swift
+++ b/Example/Views/ViewController.swift
@@ -50,7 +50,7 @@ final class ViewController: UIViewController {
     config.showCameraOption = true
     config.supportedMediaTypes = [.video, .image]
     config.firstView = self.firstView
-    config.maxNumberOfSelections = 2
+    config.maxNumberOfSelections = 5
     
     let pickerViewController = TatsiPickerViewController(config: config)
     pickerViewController.pickerDelegate = self

--- a/Tatsi.xcodeproj/project.pbxproj
+++ b/Tatsi.xcodeproj/project.pbxproj
@@ -430,15 +430,14 @@
 					};
 					0C5B61421F0D2293005A25CE = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = N4KR5KV52L;
+						DevelopmentTeam = 37BPNBN56D;
 						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 					};
 					0C5B615C1F0D231D005A25CE = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = N4KR5KV52L;
 						LastSwiftMigration = 1110;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -727,12 +726,15 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = N4KR5KV52L;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 37BPNBN56D;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "co.awkward.tatsi-example";
+				PRODUCT_BUNDLE_IDENTIFIER = "co.seesaw.tatsi-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -742,12 +744,14 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = N4KR5KV52L;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "co.awkward.tatsi-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -757,9 +761,10 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = N4KR5KV52L;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -769,6 +774,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.awkward.tatsi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -783,9 +790,10 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = N4KR5KV52L;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -795,6 +803,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.awkward.tatsi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -276,7 +276,7 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
   }
   
   fileprivate func configureForNewAlbum() {
-    title = album.localizedTitle
+    title = updateTitleBasedOnSelectedAssets()
     if let color = config?.colors.label {
       navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: color]
     }
@@ -292,6 +292,28 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
       titleView.addTarget(self, action: #selector(changeAlbum(_:)), for: .touchUpInside)
       navigationItem.titleView = titleView
     }
+  }
+  
+  fileprivate func updateTitleBasedOnSelectedAssets() -> String {
+    var updatedTitle = ""
+    let assetCount = selectedAssets.count
+    let videoSelected = selectedAssets.contains(where: { $0.mediaType == .video })
+    let photosSelected = selectedAssets.contains(where: { $0.mediaType == .image })
+    
+    if videoSelected && photosSelected {
+      // We know we have more than 1 item if both are true.
+      updatedTitle = "\(assetCount) items selected"
+    } else if videoSelected {
+      // User can only select one video.
+      updatedTitle = "\(assetCount) video selected"
+    } else if photosSelected {
+      // We only have photo(s)
+      updatedTitle = assetCount > 1 ? "\(assetCount) photos selected" : "\(assetCount) photo selected"
+    } else {
+      // There are no selected assets
+      updatedTitle = "Tap to Select"
+    }
+    return updatedTitle
   }
   
   // MARK: - Button state
@@ -469,6 +491,7 @@ extension AssetsGridViewController {
           return
         }
         selectedAssets.append(asset)
+        title = updateTitleBasedOnSelectedAssets()
         if let maxSelection = config?.maxNumberOfSelections, maxSelection == 1, config?.finishImmediatelyWithMaximumOfOne != false {
           finishPicking(with: selectedAssets)
         }
@@ -487,6 +510,7 @@ extension AssetsGridViewController {
       return
     }
     selectedAssets.remove(at: index)
+    title = updateTitleBasedOnSelectedAssets()
   }
   
 }

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -302,13 +302,13 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
     
     if videoSelected && photosSelected {
       // We know we have more than 1 item if both are true.
-      updatedTitle = "\(assetCount) items selected"
+      updatedTitle = "\(assetCount) Items Selected"
     } else if videoSelected {
       // User can only select one video.
-      updatedTitle = "\(assetCount) video selected"
+      updatedTitle = "\(assetCount) Video Selected"
     } else if photosSelected {
       // We only have photo(s)
-      updatedTitle = assetCount > 1 ? "\(assetCount) photos selected" : "\(assetCount) photo selected"
+      updatedTitle = assetCount > 1 ? "\(assetCount) Photos Selected" : "\(assetCount) Photo Selected"
     } else {
       // There are no selected assets
       updatedTitle = "Tap to Select"


### PR DESCRIPTION
Title should reflect the number of assets selected by the user.

If a user selects a photo and video then the identifier of the asset changes to `items`.
If a user selects one photo then the identifier changes to `photo`
If a user selects multiple photos then the identifier changes to `photos`
If a user selects on a video then the identifier changes to `video`

This is used in conjunction with the the `selectedAssets` count to give us a title in the format of:

```swift

"\(count) \(identifier) selected"
```
Example:

`"3 photos selected"`