### PR TITLE
add custom navbar text and appearance setting for iOS 15

### DIFF
--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -81,6 +81,15 @@ public struct TatsiConfig {
   /// The statusbar style to be used on the screens
   public var preferredStatusBarStyle: UIStatusBarStyle = .default
   
+  /// The background color for the navigation bar. Default is white.
+  public var navBarBackgroundColor: UIColor = .white
+  
+  /// The foreground color of the title text. Default is black.
+  public var navBarTitleTextColor: UIColor = .black
+  
+  /// Font style to be used for the navigation bar title.
+  public var navBarTitleFontType: UIFont?
+    
   /// Set a table name to load the localizable strings used in Tatsi from a specified localizable strings file.
   public var localizableStringsTableName: String? {
     didSet {

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -42,6 +42,15 @@ final public class TatsiPickerViewController: UINavigationController {
     fatalError("init(coder:) has not been implemented")
   }
   
+  public override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    if #available(iOS 13.0, *) {
+      setAppearanceForNavigationBar()
+      view.layoutIfNeeded()
+      view.updateConstraintsIfNeeded()
+    }
+  }
+  
   // MARK: - Helpers
   
   internal func setIntialViewController() {
@@ -79,6 +88,29 @@ final public class TatsiPickerViewController: UINavigationController {
       viewControllers = [AlbumsViewController()]
     }
   }
+  
+  @available(iOS 13, *)
+  private func setAppearanceForNavigationBar() {
+    let appearance = UINavigationBarAppearance()
+    appearance.configureWithOpaqueBackground()
+    appearance.backgroundColor = config.navBarBackgroundColor
+    if let font = config.navBarTitleFontType {
+      appearance.titleTextAttributes = [
+        .foregroundColor: config.navBarTitleTextColor,
+        NSAttributedString.Key.font: font
+      ]
+    } else {
+      appearance.titleTextAttributes = [
+        .foregroundColor: config.navBarTitleTextColor
+      ]
+    }
+    // The below line is needed for iOS 14 for some odd reason.
+    navigationBar.barTintColor = config.navBarBackgroundColor
+    navigationBar.standardAppearance = appearance
+    navigationBar.scrollEdgeAppearance = appearance
+  }
+  
+  
   
   internal func customCancelButtonItem() -> UIBarButtonItem? {
     return pickerDelegate?.cancelBarButtonItem(for: self)


### PR DESCRIPTION
- Adds use of appearance for navigation bars for iOS 13 as required on iOS 15 devices
- Allow custom font and navigation customization to be passed in